### PR TITLE
Fix: reconstruct multi-turn history during world-model inference

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -88,16 +88,28 @@ def run_inference(
         subtask = get_subtask(job)
 
         system_prompt = job.get("system_str", "")
-        current_prompt = job.get("current_prompt", "")
-        if not current_prompt:
-            prompts = job.get("prompt", [])
-            turn_idx = job.get("turn_idx", 1) - 1
-            if isinstance(prompts, list) and turn_idx < len(prompts):
-                current_prompt = prompts[turn_idx]
+        prompts = job.get("prompt", [])
+        responses = job.get("response", [])
+        if isinstance(prompts, str):
+            prompts = [prompts]
+        if isinstance(responses, str):
+            responses = [responses]
+        turn_idx = max(job.get("turn_idx", 1) - 1, 0)  # 0-indexed current turn
 
+        # Reconstruct the interaction history as interleaved user (action) /
+        # assistant (observation) turns, then append the current action. This
+        # mirrors the trajectory schema (system_prompt + [turn_1..turn_T]) and
+        # matches the context that build_judge_messages() reconstructs, so the
+        # model predicts turn t with the same prior state the judge scores against.
         messages = []
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
+        for j in range(min(turn_idx, len(prompts), len(responses))):
+            messages.append({"role": "user", "content": prompts[j]})
+            messages.append({"role": "assistant", "content": responses[j]})
+        current_prompt = job.get("current_prompt", "")
+        if not current_prompt and turn_idx < len(prompts):
+            current_prompt = prompts[turn_idx]
         messages.append({"role": "user", "content": current_prompt})
 
         try:


### PR DESCRIPTION
# Fix: reconstruct multi-turn history during world-model inference

Fixes #7

## Problem

`run_inference()` in `eval/eval.py` sent only the system prompt and the current turn's action to the world model, dropping the prior interaction history that each sample carries in its `prompt` / `response` lists. The judge (`build_judge_messages`), by contrast, reconstructs the full history as context.

As a result the model had to predict turn *t*'s observation **without** turns 1…*t*-1, while the judge scored it **with** that history — a systematic disadvantage on state-dependent domains.

## Fix

Rebuild the history in `run_inference` exactly as the judge does: interleave complete prior `(action, observation)` pairs as `user` / `assistant` turns, then append the current turn's action. The current action preserves the existing selection semantics: use `current_prompt` when present, falling back to `prompt[turn_idx-1]`.

This aligns inference with:
- the trajectory schema in the technical report §2.2 (`system_prompt ⊕ [turn_1 … turn_T]`, `turn_t = (action_t, observation_t)`),
- the world-model objective `ô_{t+1} = f_θ(c, o_{≤t}, a_{≤t})` (Eq. 1),
- and the context already used by `build_judge_messages`.

## Validation (Terminal domain, 354 samples, identical judge)

| | current-turn-only | multi-turn (this PR) | Δ |
|---|---|---|---|
| **Total** | 28.6 | **61.9** | **+33.3** |

Per-dimension gains: Format +28.0, Factuality +31.0, Consistency +50.2, Realism +27.7, Quality +29.7. A single-sample zero-judge check (Terminal maze trajectory, turn 11) shows the model output going from a blind guess to a **character-for-character match** with ground truth once history is supplied.

The reported benchmark used the full `prompt[turn_idx-1]` entry for the current turn. Following review, the final patch preserves the evaluator's existing `current_prompt`-first behavior; that exact precedence variant has not been rebenchmarked.

## Notes

- No change to the judge or scoring logic; this only fixes what the model sees at inference.
- Behavior for turn-1 samples is unchanged (no prior turns to add).
- Backward compatible with the data format; relies only on existing `prompt` / `response` / `turn_idx` fields.
